### PR TITLE
supprimer picture de l'entity article #79

### DIFF
--- a/migrations/Version20221213183644.php
+++ b/migrations/Version20221213183644.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221213183644 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE article DROP picture');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE article ADD picture VARCHAR(255) NOT NULL');
+    }
+}

--- a/src/Controller/ArticleController.php
+++ b/src/Controller/ArticleController.php
@@ -236,7 +236,6 @@ class ArticleController extends AbstractController
         
         Donec rutrum congue leo eget malesuada. Nulla quis lorem ut libero malesuada feugiat. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Proin eget tortor risus. Proin eget tortor risus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Vivamus suscipit tortor eget felis porttitor volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.');
         $florian->setImage('florian.png');
-        $florian->setPicture('florian.png');
         $florian->setMovie('Blanche-neige');
         $florian->setAuthor($walt);
         $entityManager->persist($florian);
@@ -256,7 +255,6 @@ class ArticleController extends AbstractController
         
         Donec rutrum congue leo eget malesuada. Nulla quis lorem ut libero malesuada feugiat. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Proin eget tortor risus. Proin eget tortor risus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Vivamus suscipit tortor eget felis porttitor volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.');
         $grenouille->setImage('grenouille.png');
-        $grenouille->setPicture('grenouille.png');
         $grenouille->setMovie('La princesse et la grenouille');
         $grenouille->setAuthor($walt);
         $entityManager->persist($grenouille);
@@ -274,7 +272,6 @@ class ArticleController extends AbstractController
         
         Donec rutrum congue leo eget malesuada. Nulla quis lorem ut libero malesuada feugiat. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Proin eget tortor risus. Proin eget tortor risus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Vivamus suscipit tortor eget felis porttitor volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.');
         $bete->setImage('bete.png');
-        $bete->setPicture('bete.png');
         $bete->setMovie('La belle et la bête');
         $bete->setAuthor($edith);
         $entityManager->persist($bete);
@@ -291,7 +288,6 @@ class ArticleController extends AbstractController
         
         Donec rutrum congue leo eget malesuada. Nulla quis lorem ut libero malesuada feugiat. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Proin eget tortor risus. Proin eget tortor risus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Vivamus suscipit tortor eget felis porttitor volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.');
         $merida->setImage('merida.png');
-        $merida->setPicture('merida.png');
         $merida->setMovie('Rebel');
         $merida->setAuthor($walt);
         $entityManager->persist($merida);
@@ -308,7 +304,6 @@ class ArticleController extends AbstractController
         
         Donec rutrum congue leo eget malesuada. Nulla quis lorem ut libero malesuada feugiat. Curabitur arcu erat, accumsan id imperdiet et, porttitor at sem. Mauris blandit aliquet elit, eget tincidunt nibh pulvinar a. Proin eget tortor risus. Proin eget tortor risus. Curabitur non nulla sit amet nisl tempus convallis quis ac lectus. Vivamus suscipit tortor eget felis porttitor volutpat. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi.');
         $frolo->setImage('frolo.png');
-        $frolo->setPicture('frolo.png');
         $frolo->setMovie('Le bossu de Notre-Dame');
         $frolo->setAuthor($walt);
         $entityManager->persist($frolo);
@@ -325,7 +320,6 @@ class ArticleController extends AbstractController
         
         Curabitur aliquet quam id dui posuere blandit. Donec sollicitudin molestie malesuada. Curabitur aliquet quam id dui posuere blandit. Nulla quis lorem ut libero malesuada feugiat. Praesent sapien massa, convallis a pellentesque nec, egestas non nisi. Vivamus suscipit tortor eget felis porttitor volutpat. Nulla quis lorem ut libero malesuada feugiat. Donec sollicitudin molestie malesuada. Nulla quis lorem ut libero malesuada feugiat. Vivamus suscipit tortor eget felis porttitor volutpat.');
         $cruella->setImage('cruella.png');
-        $cruella->setPicture('cruella.png');
         $cruella->setMovie('Les 101 dalmatiens');
         $cruella->setAuthor($edith);
         $entityManager->persist($cruella);

--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -26,9 +26,6 @@ class Article
     #[ORM\Column(type: Types::TEXT)]
     private ?string $content = null;
 
-    #[ORM\Column(length: 255)]
-    private ?string $picture = null;
-
     #[ORM\ManyToMany(targetEntity: Category::class, inversedBy: 'article')]
     private Collection $category;
 
@@ -84,18 +81,6 @@ class Article
     public function setContent(string $content): self
     {
         $this->content = $content;
-
-        return $this;
-    }
-
-    public function getPicture(): ?string
-    {
-        return $this->picture;
-    }
-
-    public function setPicture(string $picture): self
-    {
-        $this->picture = $picture;
 
         return $this;
     }

--- a/src/Form/ArticleType.php
+++ b/src/Form/ArticleType.php
@@ -35,9 +35,6 @@ class ArticleType extends AbstractType
             ->add('content', TextareaType::class, [
                 'label' => "Contenu de l'article"
             ])
-            ->add('picture', TextType::class, [
-                'label' => "Image de l'article",
-            ])
             ->add('image', FileType::class, [
                 'label' => 'Photo de votre personnage',
 


### PR DESCRIPTION
J'ai suivi ce tuto : https://stackoverflow.com/questions/51649730/doctrine-orm-remove-attribute-from-entity
- dans article entity supprimer le getPicture, setPicture et l'attribut picture en début de fichier
- `php bin/console doctrine:migrations:diff` pour générer un nouveau fichier de migration qui modifie la BDD en fonction des modif de l'entity
- `php bin/console doctrine:migrations:migrate` pour la traditionnelle migration
J'en ai profiter pour aussi mettre à jour la fonction article/init pour enlever picture

La preuve en image :
![image](https://user-images.githubusercontent.com/93593866/207417556-3b880889-8dc5-46e5-96a0-df4ed173451c.png)